### PR TITLE
Storage providers instantiation

### DIFF
--- a/Orleans/Test/TinkerHostTests/TinkerHostLifecycleTests.cs
+++ b/Orleans/Test/TinkerHostTests/TinkerHostLifecycleTests.cs
@@ -58,8 +58,8 @@ namespace TinkerHostTests
 
             public void Configure(ISiloBuilder silo)
             {
-                silo.ConfigureStorageProviders(factory => factory.AddAzureStorage("provider1", "connectionString1"));
-                silo.ConfigureStorageProviders(factory => factory.AddAzureStorage("provider2", "connectionString2"));
+                silo.ConfigureStorageProviders(providerBuilder => providerBuilder.AddAzureStorage("provider1", "connectionString1"));
+                silo.ConfigureStorageProviders(providerBuilder => providerBuilder.AddAzureStorage("provider2", "connectionString2"));
             }
         }
 

--- a/Orleans/Test/TinkerHostTests/TinkerHostLifecycleTests.cs
+++ b/Orleans/Test/TinkerHostTests/TinkerHostLifecycleTests.cs
@@ -83,7 +83,7 @@ namespace TinkerHostTests
             public Thingy(ILifecycleObservable lifecycle, ILoggerFactory loggerFactory)
             {
                 logger = loggerFactory.CreateLogger<Thingy>();
-                lifecycle.Subscribe(this);
+                lifecycle.Subscribe(this); //<-- passing this before finishing constructing is dangerous (although practical)
             }
 
             public Task OnInitialize()

--- a/Orleans/Test/TinkerHostTests/TinkerHostLifecycleTests.cs
+++ b/Orleans/Test/TinkerHostTests/TinkerHostLifecycleTests.cs
@@ -52,7 +52,14 @@ namespace TinkerHostTests
                 {
                     services.AddTransient(type);
                 }
+                services.AddStorageProviders();
                 return services.BuildServiceProvider();
+            }
+
+            public void Configure(ISiloBuilder silo)
+            {
+                silo.ConfigureStorageProviders(factory => factory.AddAzureStorage("provider1", "connectionString1"));
+                silo.ConfigureStorageProviders(factory => factory.AddAzureStorage("provider2", "connectionString2"));
             }
         }
 
@@ -65,6 +72,11 @@ namespace TinkerHostTests
             }
 
             public IEnumerable<Type> Members => members;
+
+            public void Configure(ISiloBuilder silo)
+            {
+                throw new NotImplementedException();
+            }
 
             public IServiceProvider ConfigureServices(IServiceCollection services)
             {

--- a/Orleans/src/Microsoft.Orleans.Host.Abstractions/AzureStorageProvider.cs
+++ b/Orleans/src/Microsoft.Orleans.Host.Abstractions/AzureStorageProvider.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Orleans.Host.Abstractions
+{
+    // this would go into the azure storage providers DLL
+    public static class AzureStorageProviderExtensions
+    {
+        public static void AddAzureStorage(this IStorageProvidersFactory factory, string providerName, string connectionString)
+        {
+            var concreteFactory = ActivatorUtilities.CreateInstance<AzureStorageProviderFactory>(factory.Silo.ApplicationServices);
+            var provider = concreteFactory.Create(providerName, connectionString);
+            factory.AddProvider(providerName, provider);
+        }
+
+    }
+
+    internal class AzureStorageProviderFactory
+    {
+        public AzureStorageProviderFactory(/* could be injected with service dependencies if needed */)
+        {
+        }
+
+        public IStorageProvider Create(string name, string connectionString)
+        {
+            return new AzureStorageProvider(/*could pass along injected dependencies*/ name, connectionString);
+        }
+    }
+
+    internal class AzureStorageProvider : IStorageProvider
+    {
+        private string connectionString;
+
+        public AzureStorageProvider(string name, string connectionString)
+        {
+            this.Name = name;
+            this.connectionString = connectionString;
+        }
+
+        public string Name { get; }
+
+        public Task Start()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task Stop()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Orleans/src/Microsoft.Orleans.Host.Abstractions/AzureStorageProvider.cs
+++ b/Orleans/src/Microsoft.Orleans.Host.Abstractions/AzureStorageProvider.cs
@@ -1,8 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Microsoft.Orleans.Host.Abstractions
@@ -10,11 +7,11 @@ namespace Microsoft.Orleans.Host.Abstractions
     // this would go into the azure storage providers DLL
     public static class AzureStorageProviderExtensions
     {
-        public static void AddAzureStorage(this IStorageProvidersFactory factory, string providerName, string connectionString)
+        public static void AddAzureStorage(this IStorageProvidersBuilder factory, string providerName, string connectionString)
         {
             var concreteFactory = ActivatorUtilities.CreateInstance<AzureStorageProviderFactory>(factory.Silo.ApplicationServices);
             var provider = concreteFactory.Create(providerName, connectionString);
-            factory.AddProvider(providerName, provider);
+            factory.AddProvider(provider);
         }
 
     }

--- a/Orleans/src/Microsoft.Orleans.Host.Abstractions/ISiloBuilder.cs
+++ b/Orleans/src/Microsoft.Orleans.Host.Abstractions/ISiloBuilder.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Orleans.Host.Abstractions
+{
+    public interface ISiloBuilder
+    {
+        /// <summary>
+        /// Gets or sets the System.IServiceProvider that provides access to the application's
+        ///    service container.
+        /// </summary>
+        IServiceProvider ApplicationServices { get; set; }
+        
+        /// <summary>
+        /// Gets a key/value collection that can be used to share data between middleware.
+        /// </summary>
+        IDictionary<string, object> Properties { get; }
+
+
+        //IFeatureCollection ServerFeatures { get; }
+    }
+}

--- a/Orleans/src/Microsoft.Orleans.Host.Abstractions/IStartup.cs
+++ b/Orleans/src/Microsoft.Orleans.Host.Abstractions/IStartup.cs
@@ -9,5 +9,6 @@ namespace Microsoft.Orleans.Host.Abstractions
     {
         IEnumerable<Type> Members { get; } // not sure I understand why this?
         IServiceProvider ConfigureServices(IServiceCollection services);
+        void Configure(ISiloBuilder silo);
     }
 }

--- a/Orleans/src/Microsoft.Orleans.Host.Abstractions/IStartup.cs
+++ b/Orleans/src/Microsoft.Orleans.Host.Abstractions/IStartup.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Orleans.Host.Abstractions
 {
     public interface IStartup
     {
-        IEnumerable<Type> Members { get; }
+        IEnumerable<Type> Members { get; } // not sure I understand why this?
         IServiceProvider ConfigureServices(IServiceCollection services);
     }
 }

--- a/Orleans/src/Microsoft.Orleans.Host.Abstractions/Microsoft.Orleans.Host.Abstractions.csproj
+++ b/Orleans/src/Microsoft.Orleans.Host.Abstractions/Microsoft.Orleans.Host.Abstractions.csproj
@@ -52,9 +52,12 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AzureStorageProvider.cs" />
     <Compile Include="IHost.cs" />
     <Compile Include="IHostBuilder.cs" />
+    <Compile Include="ISiloBuilder.cs" />
     <Compile Include="IStartup.cs" />
+    <Compile Include="StorageProvidersFeature.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Orleans/src/Microsoft.Orleans.Host.Abstractions/StorageProvidersFeature.cs
+++ b/Orleans/src/Microsoft.Orleans.Host.Abstractions/StorageProvidersFeature.cs
@@ -6,38 +6,39 @@ using System.Threading.Tasks;
 namespace Microsoft.Orleans.Host.Abstractions
 {
     // this would go into the (optional) storage providers DLL.
-    public interface IStorageProvidersFactory
+    public interface IStorageProvidersBuilder
     {
         ISiloBuilder Silo { get; }
-        void AddProvider(string name, IStorageProvider provider);
+        void AddProvider(IStorageProvider provider);
     }
 
     public static class SiloStorageProviderExtensions
     {
         public static void AddStorageProviders(this IServiceCollection services)
         {
-            services.AddSingleton<IStorageProvidersFactory, StorageProvidersFactory>();
+            services.AddSingleton<IStorageProvidersBuilder, StorageProvidersBuilder>();
         }
-        public static void ConfigureStorageProviders(this ISiloBuilder silo, Action<IStorageProvidersFactory> configureMethod)
+        public static void ConfigureStorageProviders(this ISiloBuilder silo, Action<IStorageProvidersBuilder> configureMethod)
         {
-            var factory = silo.ApplicationServices.GetRequiredService<IStorageProvidersFactory>();
+            var factory = silo.ApplicationServices.GetRequiredService<IStorageProvidersBuilder>();
             configureMethod(factory);
         }
 
     }
 
-    public class StorageProvidersFactory : IStorageProvidersFactory
+    public class StorageProvidersBuilder : IStorageProvidersBuilder
     {
+        // these would then be passed on to the provider manager so it can manage their lifetime
         private Dictionary<string, IStorageProvider> providers = new Dictionary<string, IStorageProvider>();
-        public StorageProvidersFactory(ISiloBuilder silo)
+        public StorageProvidersBuilder(ISiloBuilder silo)
         {
             Silo = silo;
         }
         public ISiloBuilder Silo { get; }
 
-        public void AddProvider(string name, IStorageProvider provider)
+        public void AddProvider(IStorageProvider provider)
         {
-            this.providers.Add(name, provider);
+            this.providers.Add(provider.Name, provider);
         }
     }
 

--- a/Orleans/src/Microsoft.Orleans.Host.Abstractions/StorageProvidersFeature.cs
+++ b/Orleans/src/Microsoft.Orleans.Host.Abstractions/StorageProvidersFeature.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.Orleans.Host.Abstractions
+{
+    // this would go into the (optional) storage providers DLL.
+    public interface IStorageProvidersFactory
+    {
+        ISiloBuilder Silo { get; }
+        void AddProvider(string name, IStorageProvider provider);
+    }
+
+    public static class SiloStorageProviderExtensions
+    {
+        public static void AddStorageProviders(this IServiceCollection services)
+        {
+            services.AddSingleton<IStorageProvidersFactory, StorageProvidersFactory>();
+        }
+        public static void ConfigureStorageProviders(this ISiloBuilder silo, Action<IStorageProvidersFactory> configureMethod)
+        {
+            var factory = silo.ApplicationServices.GetRequiredService<IStorageProvidersFactory>();
+            configureMethod(factory);
+        }
+
+    }
+
+    public class StorageProvidersFactory : IStorageProvidersFactory
+    {
+        private Dictionary<string, IStorageProvider> providers = new Dictionary<string, IStorageProvider>();
+        public StorageProvidersFactory(ISiloBuilder silo)
+        {
+            Silo = silo;
+        }
+        public ISiloBuilder Silo { get; }
+
+        public void AddProvider(string name, IStorageProvider provider)
+        {
+            this.providers.Add(name, provider);
+        }
+    }
+
+    public interface IStorageProvider
+    {
+        string Name { get; }
+        Task Start();
+        Task Stop();
+    }
+}


### PR DESCRIPTION
This PR is just work in progress before I go to sleep, but it is basically how I envision the providers instantiation (as we know they are not singleton services).
This is modeled from how AspNet allows optional features.
The important thing is how the Startup class looks like, and how the configuration is done via extension methods on `IServiceCollection` and `ISiloBuilder` (the latter I added emulating the IApplicationBuilder from Asp.NET)

This does not yet use `IOptions<T>` to configure the storage providers' specific info, but that's coming later if you feel the approach is good.

For now I put everything in the abstractions project, but in theory they should be moved to different pieces (I added code comments specifying where they should live).
